### PR TITLE
Feat: G3-Task 16.3-Backend galería comisiones finalizadas

### DIFF
--- a/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionController.java
+++ b/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionController.java
@@ -1,5 +1,7 @@
 package com.HolosINC.Holos.commision;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,6 +10,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.HolosINC.Holos.commision.DTOs.ClientCommissionDTO;
 import com.HolosINC.Holos.commision.DTOs.CommisionRequestDTO;
 import com.HolosINC.Holos.commision.DTOs.CommissionDTO;
 import com.HolosINC.Holos.commision.DTOs.HistoryCommisionsDTO;
@@ -143,5 +147,18 @@ public class CommisionController {
             return ResponseEntity.badRequest().body("⚠ Error interno: " + e.getMessage());
         }
     }
+
+    @GetMapping("/ended/client")
+    public ResponseEntity<?> getEndedCommissionsForClient() {
+        try {
+            List<ClientCommissionDTO> commissions = commisionService.getEndedCommissionsForClient();
+            return ResponseEntity.ok(commissions);
+        } catch (IllegalAccessException e) {
+            return ResponseEntity.status(403).body("Acceso denegado: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Error al obtener las comisiones finalizadas: " + e.getMessage());
+        }
+    }
+
 
 }

--- a/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionRepository.java
+++ b/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionRepository.java
@@ -47,4 +47,9 @@ public interface CommisionRepository extends JpaRepository<Commision, Long>{
 
     @Query("SELECT c.id FROM Commision c WHERE c.paymentIntentId = :paymentIntentId")
     Long findCommissionIdByPaymentIntentId(@Param("paymentIntentId") String paymentIntentId);
+
+    @Query("SELECT new com.HolosINC.Holos.commision.DTOs.ClientCommissionDTO(c) " + "FROM Commision c " + 
+    "WHERE c.client.baseUser.id = :clientId AND c.status = com.HolosINC.Holos.commision.StatusCommision.ENDED")
+    List<ClientCommissionDTO> findEndedCommissionsByClientId(Long clientId);
+
 }

--- a/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionService.java
+++ b/Backend/src/main/java/com/HolosINC/Holos/commision/CommisionService.java
@@ -362,5 +362,17 @@ public class CommisionService {
     public boolean isStatusKanbanInUse(StatusKanbanOrder status) {
         return commisionRepository.existsByStatusKanban(status);
     }
+
+    @Transactional(readOnly = true)
+    public List<ClientCommissionDTO> getEndedCommissionsForClient() throws Exception {
+        BaseUser currentUser = userService.findCurrentUser();
+
+        if (!clientService.isClient(currentUser.getId())) {
+            throw new IllegalAccessException("Solo los clientes pueden ver su galería de comisiones finalizadas.");
+        }
+
+        return commisionRepository.findEndedCommissionsByClientId(currentUser.getId());
+    }
+
     
 }

--- a/Backend/src/main/resources/data.sql
+++ b/Backend/src/main/resources/data.sql
@@ -236,7 +236,7 @@ INSERT INTO commisions (id, artist_id, name, description, price, client_id, stat
 
 -- Comisiones para el Artista 2(ID 2)
 INSERT INTO commisions (id, artist_id, name, description, price, client_id, status, accepted_date_by_artist, payment_arrangement, status_kanban_order_id) VALUES
-(11, 2, 'Sunset Painting', 'A beautiful sunset painting', 150.0, 1, 'ACCEPTED', '2025-03-01', 'INITIAL', 11),
+(11, 2, 'Sunset Painting', 'A beautiful sunset painting', 150.0, 1, 'ENDED', '2025-03-01', 'INITIAL', 11),
 (12, 2, 'Ocean Waves', 'A calming ocean scene with waves', 200.0, 2, 'ACCEPTED', '2025-03-02', 'FINAL', 12),
 (13, 2, 'Forest at Dusk', 'A mysterious forest at dusk', 210.0, 3, 'REQUESTED', '2025-03-22', 'FINAL', NULL),
 (14, 2, 'Abstract Faces', 'A contemporary painting of abstract faces', 250.0, 4, 'REQUESTED', '2025-03-23', 'INITIAL', NULL),


### PR DESCRIPTION
- Añadido método getEndedCommissionsForClient en CommisionService para recuperar todas las comisiones del cliente autenticado cuyo estado es ENDED.
- Añadido método findEndedCommissionsByClientId en CommisionRepository, usando CommissionDTO para devolver los datos de manera optimizada.
- Creado nuevo endpoint GET /api/v1/commisions/ended/client en CommisionController para exponer los datos necesarios para la galería.
- Preparado el backend para que el frontend pueda mostrar la galería de comisiones finalizadas en el perfil del cliente.